### PR TITLE
Fpc fix

### DIFF
--- a/tbl_maken.R
+++ b/tbl_maken.R
@@ -571,7 +571,7 @@ log.save = T
       }
       # merge zodat we voor elke respondent een sampling prob hebben
       fpc_per_respondent <- data.frame(
-        stratum = strata %>% as.factor
+        stratum = strata
       ) %>% left_join(
         fpc_data,
         join_by(stratum==stratum)


### PR DESCRIPTION
De huidige code crasht wanneer er geen FPC wordt uitgevoerd. Fix toegevoegd waarbij de volgorde wordt omgedraaid; eerst herschrijven van de strata, dan pas FPC. Daardoor is er geen type mismatch voor de strata van dbl naar chr.